### PR TITLE
feat: add work arrangement field for jobs (on-site, remote, hybrid) i…

### DIFF
--- a/client/src/components/admin/PostJob.jsx
+++ b/client/src/components/admin/PostJob.jsx
@@ -24,7 +24,13 @@ const PostJob = () => {
         experience: '',
         position: 0,
         companyId: '',
+        workArrangement: '',
     });
+    const workArrangementOptions = ["On-site", "Hybrid", "Remote"];
+
+    const workArrangementChangeHandler = (value) => {
+        setInput({ ...input, workArrangement: value });
+    };
     const [loading, setLoading] = useState(false);
     const navigate = useNavigate();
 
@@ -167,6 +173,25 @@ const PostJob = () => {
                                 onChange={ changeEventHandler }
                                 className="my-1 border-blue-300 focus:ring-blue-500 focus:border-blue-500"
                             />
+                        </div>
+                        <div>
+                            <Label>
+                                Work Arrangement <span className="text-red-500">*</span>
+                            </Label>
+                            <Select onValueChange={ workArrangementChangeHandler } value={input.workArrangement}>
+                                <SelectTrigger className="w-full">
+                                    <SelectValue placeholder="Select Work Arrangement" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    <SelectGroup>
+                                        {workArrangementOptions.map((option) => (
+                                            <SelectItem key={option} value={option}>
+                                                {option}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectGroup>
+                                </SelectContent>
+                            </Select>
                         </div>
                         <div>
                             <Label>

--- a/server/controllers/job.controller.js
+++ b/server/controllers/job.controller.js
@@ -3,10 +3,10 @@ import { Job } from "../models/job.model.js";
 
 export const postJob = async(req, res) => {
     try {
-        const { title, description, requirements, salary, location, jobType, experience, position, companyId } = req.body;
+        const { title, description, requirements, salary, location, jobType, experience, position, companyId, workArrangement } = req.body;
         const userId = req.id;
 
-        if (!title || !description || !requirements || !salary || !location || !jobType || !experience || !position || !companyId) {
+        if (!title || !description || !requirements || !salary || !location || !jobType || !experience || !position || !companyId || !workArrangement) {
             return res.status(400).json({
                 message: "Somethin is missing.",
                 success: false
@@ -22,6 +22,7 @@ export const postJob = async(req, res) => {
             experienceLevel: experience,
             position,
             company: companyId,
+            workArrangement,
             created_by: userId
         });
         return res.status(201).json({

--- a/server/models/job.model.js
+++ b/server/models/job.model.js
@@ -16,6 +16,11 @@ const jobSchema = new mongoose.Schema({
         type: Number,
         required: true
     },
+    workArrangement: {
+        type: String,
+        enum: ["On-site", "Hybrid", "Remote"],
+        required: true
+    },
     experienceLevel: {
         type: String,
     },


### PR DESCRIPTION
## PR: Add Work Arrangement Field to Job Posting (On-site, Remote, Hybrid)

### Description
This PR introduces a new "Work Arrangement" field to the job posting workflow for recruiters. The field allows recruiters to specify whether a job is **On-site**, **Remote**, or **Hybrid**.


### Key Changes

- **Frontend**
  - Added a "Work Arrangement" dropdown to the job post form.
  - Options include: On-site, Hybrid, Remote.

- **Backend**
  - Updated the Job schema to include a required `workArrangement` field (`enum`: On-site, Hybrid, Remote).
  - Modified the job controller to accept, validate, and save the new field.

### Why

This feature enables recruiters to clearly communicate the work arrangement for each job, improving candidate experience and filtering.

