### PR TITLE
feat(nav): add Profile and Logout to mobile menu for  jobseekers and logged-in users

### DIFF
--- a/client/src/components/shared/Navbar.jsx
+++ b/client/src/components/shared/Navbar.jsx
@@ -180,7 +180,19 @@ const Navbar = () => {
                                 <li className="cursor-pointer hover:text-white">
                                     <Link to="/browse">Browse</Link>
                                 </li>
+                                {user && user.role === 'jobseeker' && (
+                                    <li className="cursor-pointer hover:text-white">
+                                        <Link to="/profile">Profile</Link>
+                                    </li>
+                                )}
                             </>
+                        )}
+                        {user && (
+                            <li>
+                                <Button onClick={logoutHandler} variant="ghost" className="w-full text-red-400 flex items-center gap-2 justify-center">
+                                    <LogOut className="w-4 h-4" /> Logout
+                                </Button>
+                            </li>
                         )}
                         { !user && (
                             <div className="flex flex-col gap-2">


### PR DESCRIPTION
## Add Profile and Logout to Mobile Navigation

### Summary

Improved the mobile navigation menu to include missing key actions for logged-in users, making the navigation experience consistent with desktop.

### Details

- Added a "Profile" link to the mobile menu for jobseekers, so users can access their profile from any device.
- Added a "Logout" button to the mobile menu for all logged-in users, making it easy to log out on small screens.
- The mobile menu now shows: Home, Jobs, Browse, Profile (for jobseekers), and Logout (when logged in).
- For users not logged in, Login and Signup buttons are still shown.
- These changes make the navigation more user-friendly and consistent across all screen sizes.